### PR TITLE
nitfix: create log directory if not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,12 +156,14 @@ optional arguments:
 To run with stock python and stock technologies, logging the performance to `logs/stock_stock.log`, we would run (after creating the appropriate environment as above) from `src` directory:
 ```shell
 conda activate doc_class_stock
+mkdir -p ../logs  # create `logs` dir in the parent dir if not present
 python run_benchmarks.py -l ../logs/stock_stock.log
 ```
 
 To run with Intel® technologies, logging the performance to `logs/intel_intel.log`, we woud run (after creating the appropriate environment as above):
 ```shell
 conda activate doc_class_intel
+mkdir -p ../logs  # create `logs` dir in the parent dir if not present
 python run_benchmarks.py -i -l ../logs/intel_intel.log
 ```
 

--- a/data/README.md
+++ b/data/README.md
@@ -1,4 +1,3 @@
-#review commnent posted(delete later)
 ## Setting up the data
 
 The benchmarking scripts expects 2 files to be present in `data/huffpost`.


### PR DESCRIPTION
Without the log directory being present, the `run_benchmark.py` command fails.
Adding a command to create the directory in the parent dir if `logs` dir is not present.